### PR TITLE
Travis CI: Lint Python code for undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
+os: linux
+dist: xenial
 language: python
 python:
   - "3.8"
-
-install:
-  - pip install numpy
-  - pip install opencv-python
-dist: xenial
 services:
   - xvfb
+
+install: pip install flake8 numpy opencv-python
   
-script: python eyeloop.py --video 'examples/optokinetic-reflex/Wild-type.avi'
+script:
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+  - python eyeloop.py --video 'examples/optokinetic-reflex/Wild-type.avi'

--- a/eyeloop.py
+++ b/eyeloop.py
@@ -3,8 +3,6 @@ sys.path.append('../')
 
 from engine.engine import Engine
 
-from importers.vimba import Importer
-
 from utilities.format_print import clear, welcome
 from utilities.argument_parser import Arguments
 from utilities.file_manager import File_Manager
@@ -43,6 +41,7 @@ class EyeLoop:
             print("Initiating tracking via {}".format(arguments.importer))
             import_command = "from importers.{} import Importer".format(arguments.importer)
             exec(import_command, globals())
+            global Importer
         except Exception as e:
             print("Invalid importer selected.\n", e)
 

--- a/eyeloop.py
+++ b/eyeloop.py
@@ -51,5 +51,4 @@ class EyeLoop:
 
 
 if __name__ == '__main__':
-
     EyeLoop()

--- a/eyeloop.py
+++ b/eyeloop.py
@@ -3,6 +3,8 @@ sys.path.append('../')
 
 from engine.engine import Engine
 
+from importers.vimba import Importer
+
 from utilities.format_print import clear, welcome
 from utilities.argument_parser import Arguments
 from utilities.file_manager import File_Manager
@@ -44,7 +46,7 @@ class EyeLoop:
         except Exception as e:
             print("Invalid importer selected.\n", e)
 
-        importer  =   Importer(ENGINE)
+        importer = Importer(ENGINE)
 
         importer.route()
 


### PR DESCRIPTION
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.