### PR TITLE
Use pathlib instead of os

### DIFF
--- a/utilities/file_manager.py
+++ b/utilities/file_manager.py
@@ -1,7 +1,9 @@
 import time
-import os
 import cv2
 import numpy as np
+
+from pathlib import Path
+
 
 class File_Manager:
     """
@@ -13,18 +15,17 @@ class File_Manager:
     """
     def __init__(self, dir:str) -> None:
 
-        self.directory = dir + "/data"
-        self.input_folderpath = ""
+        self.directory = Path(f"{dir}/data")
 
         try:
-            os.mkdir(self.directory)
+            self.directory.mkdir()
         except FileExistsError:
             print("'{}' already exists.".format(self.directory))
 
         timestamp = time.strftime("%Y%m%d-%H%M%S")
-        self.new_folderpath = "{}/trial_{}".format(self.directory, timestamp)
+        self.new_folderpath = Path(self.directory / f"trial_{timestamp}")
 
-        os.mkdir(self.new_folderpath)
+        self.new_folderpath.mkdir()
 
     def save_image(self, image:np.ndarray, frame:int) -> None:
         """


### PR DESCRIPTION
Executing `python eyeloop`, and noticed that in the beginning of the logs it says

`'/home/kinow/Development/python/workspace/eyeloop//data' already exists.`

There is a double `/`, which indicated probably some string concatenation. The Py3+ [`pathlib`](https://docs.python.org/3/library/pathlib.html) stdlib module provides good features for handling with path navigation, creating directories.

It adds a new abstraction layer over the existing `os` code. This PR uses `pathlib`, and the log now produces.

`'/home/kinow/Development/python/workspace/eyeloop/data' already exists.`

Also confirmed the trial folder was created within `./data` directory.