### PR TITLE
Fix loop errors

### DIFF
--- a/engine/processor.py
+++ b/engine/processor.py
@@ -93,7 +93,9 @@ class Shape():
 
         try:
 
-            if config.engine.blink_i == 1:
+            # FIXME: while the hasattr is fixing the exception, it is not the
+            #        most elegant solution (nor probably the right one)
+            if config.engine.blink_i == 1 and hasattr(self, 'standard_corners'):
                 self.corners        = self.standard_corners.copy()
                 self.walkout_offset = 0
                 self.refresh_source(self.source)
@@ -151,7 +153,8 @@ class Shape():
                 ellipse = 0
 
         except Exception as e:
-            print(e)
+            import traceback
+            traceback.print_exc()
             return False
 
         if ellipse == fit_product:

--- a/engine/processor.py
+++ b/engine/processor.py
@@ -131,6 +131,10 @@ class Shape():
                     #cv2.imshow("JJ", self.source)
                     #cv2.waitKey(0)
 
+            # center has not been initialized yet
+            if self.center == -1:
+                return False
+
             center = [self.center[0] - self.corners[0][0], self.center[1] - self.corners[0][1]]
             walkout = self.walkout
             walkout.reset(center)


### PR DESCRIPTION
Hi!

When I start the GUI, the console is full of warnings such as `'int' object is not subscriptable`. The first commit in this PR shows where that is coming from. The `self.center` value is `-1`, and the first time the code proceeds, it tries to access `self.center[...]` resulting in that error.

The second error, that happens with less frequency, is `'Shape' object has no attribute 'standard_corners'`. It appears that `standard_corners`, `area`, and other attributes are initialized in the `reset` - or in other functions - but are used before the `reset` initializes the attributes.

Resulting in `no attribute` error. The fix in this PR removes the error from the log, but that's most likely not the right solution. Feel free to close this PR if there's another solution in progress (cc @cfculhane you said you are refactoring some of the code?).