### PR TITLE
Fix Path name

### DIFF
--- a/eyeloop/importers/cv.py
+++ b/eyeloop/importers/cv.py
@@ -14,8 +14,8 @@ class Importer(IMPORTER):
     def first_frame(self) -> None:
         self.vid_path = Path(config.arguments.video)
         # load first frame
-        if self.vid_path.is_file() is True:  # or stream
-            if self.vid_path == "0":
+        if self.vid_path.name == "0" or self.vid_path.is_file():  # or stream
+            if self.vid_path.name == "0":
                 self.capture = cv2.VideoCapture(0)
             else:
                 self.capture = cv2.VideoCapture(str(self.vid_path))
@@ -29,7 +29,7 @@ class Importer(IMPORTER):
                 image = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
             except:
                 image = image[..., 0]
-        elif self.vid_path.is_dir() is True:
+        elif self.vid_path.is_dir():
 
             config.file_manager.input_folderpath = self.vid_path
 


### PR DESCRIPTION
Hi!

I had a look at the changes from yesterday, and looking at this commit 3bb6d3b50efb3ec7618940daab210dec3184adeb changed a bit the `cv` importer.

The old `check_path_type` function, in `eyeloop/utilities/general_operations.py` started by checking if the file name was "0". If so, it would go into a branch of the `if/else` logic that starts the GUI.

I changed a little the current code to match the old code, and got it working as yesterday.

@simonarvin I can confirm too, that after this I can press 1, 2, 3, etc on the GUI, and it doesn't crash! :tada: so I will close #10 

Not sure if the best fix, or if there's something that needs changing in the other importer, or in the base class?

Thanks!
Bruno