### PR TITLE
Add setup.py and setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,9 @@ python:
   - "3.8"
 
 install:
-  - pip install numpy
-  - pip install opencv-contrib-python
+  - pip install -e .
 dist: xenial
 services:
   - xvfb
 
-script: python eyeloop/run_eyeloop.py --video 'misc/travis-sample/Frmd7.m4v'
+script: eyeloop --video 'misc/travis-sample/Frmd7.m4v'

--- a/README.md
+++ b/README.md
@@ -56,8 +56,16 @@ Install EyeLoop simply by cloning the repository:
 git clone https://github.com/simonarvin/eyeloop.git
 ```
 
->Dependencies:
-> ```python pip install -r requirements.txt```
+>Using pip:
+> ```pip install .```
+
+You may want to use a Conda or Python virtual environment when
+installing `eyeloop`, to avoid mixing up with your system dependencies.
+
+>Using pip and a virtual environment:
+> ```python -m venv venv```
+> ```source venv/bin/activate```
+> ```(venv) pip install .```
 
 Alternatively:
 
@@ -74,19 +82,19 @@ git clone https://github.com/simonarvin/eyeloop_playground.git
 
 ### Initiation ###
 
-EyeLoop is initiated through the command-line interface.
+EyeLoop is initiated through the command-line utility `eyeloop`.
 ```
-python eyeloop/run_eyeloop.py
+eyeloop
 ```
 To access the video sequence, EyeLoop must be connected to an appropriate *importer class* module. Usually, the default opencv importer class (*cv*) is sufficient. For some machine vision cameras, however, a vimba-based importer (*vimba*) is neccessary.
 ```
-python eyeloop/run_eyeloop.py --importer cv/vimba
+eyeloop --importer cv/vimba
 ```
 > [Click here](https://github.com/simonarvin/eyeloop/blob/master/eyeloop/importers/README.md) for more information on *importers*.
 
 To perform offline eye-tracking, we pass the video argument ```--video``` with the path of the video sequence:
 ```
-python eyeloop/run_eyeloop.py --video [file]/[folder]
+eyeloop --video [file]/[folder]
 ```
 <p align="right">
     <img src="https://github.com/simonarvin/eyeloop/blob/master/misc/imgs/models.svg?raw=true" align="right" height="150">
@@ -95,14 +103,14 @@ python eyeloop/run_eyeloop.py --video [file]/[folder]
 EyeLoop can be used on a multitude of eye types, including rodents, human and non-human primates. Specifically, users can suit their eye-tracking session to any species using the ```--model``` argument.
 
 ```
-python eyeloop/run_eyeloop.py --model ellipsoid/circular
+eyeloop --model ellipsoid/circular
 ```
 > In general, the ellipsoid pupil model is best suited for rodents, whereas the circular model is best suited for primates.
 
 To see all command-line arguments, pass:
 
 ```
-python eyeloop/run_eyeloop.py --help
+eyeloop --help
 ```
 
 ## Designing your first experiment ##
@@ -168,7 +176,7 @@ By using ```fetch()```, we shift the phase of the sine function at every time-st
 
 That's it! Test your experiment using:
 ```
-python eyeloop/run_eyeloop.py
+eyeloop
 ```
 > See [Examples](https://github.com/simonarvin/eyeloop/blob/master/examples) for demo recordings and experimental designs.
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Install EyeLoop simply by cloning the repository:
 git clone https://github.com/simonarvin/eyeloop.git
 ```
 
+>Dependencies: ```python -m pip install -r requirements.txt```
+
 >Using pip:
 > ```pip install .```
 

--- a/eyeloop/engine/engine.py
+++ b/eyeloop/engine/engine.py
@@ -2,10 +2,10 @@ import time
 
 import cv2
 
-import config
-from constants.engine_constants import *
-from engine.processor import Shape
-from utilities.general_operations import to_int, tuple_int
+import eyeloop.config as config
+from eyeloop.constants.engine_constants import *
+from eyeloop.engine.processor import Shape
+from eyeloop.utilities.general_operations import to_int, tuple_int
 
 
 class Engine:

--- a/eyeloop/engine/models/circular.py
+++ b/eyeloop/engine/models/circular.py
@@ -5,7 +5,7 @@
 
 import numpy as np
 
-from utilities.general_operations import tuple_int
+from eyeloop.utilities.general_operations import tuple_int
 
 
 class Circle:

--- a/eyeloop/engine/models/ellipsoid.py
+++ b/eyeloop/engine/models/ellipsoid.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from utilities.general_operations import tuple_int
+from eyeloop.utilities.general_operations import tuple_int
 
 """Demonstration of least-squares fitting of ellipses
     __author__ = "Ben Hammel, Nick Sullivan-Molina"

--- a/eyeloop/engine/processor.py
+++ b/eyeloop/engine/processor.py
@@ -1,10 +1,10 @@
 import cv2
 
-import config
-from constants.processor_constants import *
-from engine.models.circular import Circle
-from engine.models.ellipsoid import Ellipse
-from utilities.general_operations import to_int, tuple_int
+import eyeloop.config as config
+from eyeloop.constants.processor_constants import *
+from eyeloop.engine.models.circular import Circle
+from eyeloop.engine.models.ellipsoid import Ellipse
+from eyeloop.utilities.general_operations import to_int, tuple_int
 
 
 class Shape():

--- a/eyeloop/guis/minimum/minimum_gui.py
+++ b/eyeloop/guis/minimum/minimum_gui.py
@@ -2,9 +2,9 @@ import os
 
 import numpy as np
 
-import config
-from constants.minimum_gui_constants import *
-from utilities.general_operations import to_int, tuple_int
+import eyeloop.config as config
+from eyeloop.constants.minimum_gui_constants import *
+from eyeloop.utilities.general_operations import to_int, tuple_int
 
 
 class GUI:

--- a/eyeloop/importers/cv.py
+++ b/eyeloop/importers/cv.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import cv2
 
-import config
-from importers.importer import IMPORTER
+import eyeloop.config as config
+from eyeloop.importers.importer import IMPORTER
 
 
 class Importer(IMPORTER):

--- a/eyeloop/importers/importer.py
+++ b/eyeloop/importers/importer.py
@@ -1,8 +1,8 @@
 import cv2
 import numpy as np
 
-import config
-from utilities.general_operations import tuple_int
+import eyeloop.config as config
+from eyeloop.utilities.general_operations import tuple_int
 
 
 class IMPORTER:

--- a/eyeloop/importers/vimba.py
+++ b/eyeloop/importers/vimba.py
@@ -3,8 +3,8 @@ import time
 from pymba import Frame
 from pymba import Vimba
 
-import config
-from importers.importer import IMPORTER
+import eyeloop.config as config
+from eyeloop.importers.importer import IMPORTER
 
 
 # For pymba documentation, see:

--- a/eyeloop/run_eyeloop.py
+++ b/eyeloop/run_eyeloop.py
@@ -1,15 +1,15 @@
-from engine.engine import Engine
+from eyeloop.engine.engine import Engine
 
-from utilities.format_print import welcome
-from utilities.argument_parser import Arguments
-from utilities.file_manager import File_Manager
+from eyeloop.utilities.format_print import welcome
+from eyeloop.utilities.argument_parser import Arguments
+from eyeloop.utilities.file_manager import File_Manager
 
-from extractors.DAQ import DAQ_extractor
-from extractors.frametimer import FPS_extractor
+from eyeloop.extractors.DAQ import DAQ_extractor
+from eyeloop.extractors.frametimer import FPS_extractor
 
-from guis.minimum.minimum_gui import GUI
+from eyeloop.guis.minimum.minimum_gui import GUI
 
-import config
+import eyeloop.config as config
 
 
 class EyeLoop:
@@ -38,7 +38,7 @@ class EyeLoop:
 
         try:
             print("Initiating tracking via {}".format(config.arguments.importer))
-            import_command = "from importers.{} import Importer".format(config.arguments.importer)
+            import_command = "from eyeloop.importers.{} import Importer".format(config.arguments.importer)
 
             exec(import_command, globals())
 

--- a/eyeloop/run_eyeloop.py
+++ b/eyeloop/run_eyeloop.py
@@ -11,6 +11,7 @@ from eyeloop.guis.minimum.minimum_gui import GUI
 
 import eyeloop.config as config
 
+import sys
 
 class EyeLoop:
     """
@@ -47,6 +48,7 @@ class EyeLoop:
 
         config.importer = Importer()
         config.importer.route()
+        sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/eyeloop/utilities/format_print.py
+++ b/eyeloop/utilities/format_print.py
@@ -1,6 +1,6 @@
 from os import system, name
 
-import config
+import eyeloop.config as config
 
 tab = "       "
 linebreak = "\n{}{}\n".format(tab, 30 * "_")

--- a/eyeloop/utilities/parser.py
+++ b/eyeloop/utilities/parser.py
@@ -2,7 +2,7 @@ import json
 from tkinter import filedialog
 
 import numpy as np
-from interfaces.converter import Conversion_extractor
+from eyeloop.extractors.converter import Conversion_extractor
 
 
 class Parser():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+opencv-contrib-python>=4.2.*
+pymba==0.3.*
+numpy==1.19.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-opencv-contrib-python
-pymba
-numpy

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python
-from glob import glob
-from os.path import join
-
 from setuptools import setup, find_packages
 
 
-install_requires = [
-    'opencv-contrib-python>=4.2.*',
-    'pymba==0.3.*',
-    'numpy==1.19.*'
-]
+install_requires = install_requires = []
+
+with open('requirements.txt') as f:
+    for line in f.readlines():
+        req = line.strip()
+        if not req or req.startswith('#') or '://' in req:
+            continue
+        install_requires.append(req)
+
 
 setup(
     name='eyeloop',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+from glob import glob
+from os.path import join
+
+from setuptools import setup, find_packages
+
+
+install_requires = [
+    'opencv-contrib-python>=4.2.*',
+    'pymba==0.3.*',
+    'numpy==1.19.*'
+]
+
+setup(
+    name='eyeloop',
+    description='EyeLoop is a Python 3-based eye-tracker tailored specifically to dynamic, '
+                'closed-loop experiments on consumer-grade hardware.',
+    long_description=open('README.md').read(),
+    long_description_content_type="text/markdown",
+    url='https://github.com/simonarvin/eyeloop',
+    license='GPL',
+    license_file='LICENSE',
+    platforms='any',
+    python_requires='>=3.7',
+    version='0.1',
+    entry_points={
+        'console_scripts': [
+            'eyeloop=eyeloop.run_eyeloop:EyeLoop'
+        ]
+    },
+    packages=find_packages(include=["eyeloop.*"]),
+    install_requires=install_requires,
+    project_urls={
+        "Documentation": "https://github.com/simonarvin/eyeloop",
+        "Source": "https://github.com/simonarvin/eyeloop",
+        "Tracker": "https://github.com/simonarvin/eyeloop/issues"
+    }
+)


### PR DESCRIPTION
Hi!

This pull request adds setuptools to the project, with a simple `setup.py` (used an existing project I maintain as reference, and the [Python docs](https://setuptools.readthedocs.io/en/latest/setuptools.html) too to remind me of some syntax and configuration).

I normally use virtual environments, or occasionally Conda environments. And also use the IDE with projects I am reading the code or testing. So my workflow is normally:

```bash
python -m venv venv
source venv/bin/activate
(venv) pip install -e . # install editable, so that I can change code and keep debugging in the IDE
(venv) # now anything in this virtual environment is self-contained, even scripts like `eyeloop` would exist only here
```

The pre-print paper I think mentions `eyeloop.py`, and the new docs `eyeloop/run_eyeloop.py`. In this pull request, I used [entry points](https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation) of setuptools.

This is a feature in setuptools that allows us to use an existing Python function in a module (e.g. `eyeloop.run_eyeloop:Eyeloop`) and map it as a Python script automatically created by setuptools, and added to the `$PATH` variable when the virtual environment is activated.

Using this feature, users can run simply `eyeloop`. That should take care of choosing the right interpreter, loading dependencies, and starting the GUI.

Not sure if the metadata is complete. There are many classifiers that can be used to help users finding the project via PYPI. Here's the complete [list](https://pypi.org/classifiers/).

Another advantage of using setuptools, is that once we are able to install with `pip install .`, it is quite simple to upload it to PYPI too with `twine` or a similar tool. This way, users would be able to install it via `pip install eyeloop` or some other similar package name (it's not in use now, might be a good idea to register the module if there are any intention of publishing it with that name).

And furthermore, once published to PYPI, if we upload a sdist (source distribution; you can choose to upload wheel binaries only, or source only, or multiple packages) then a Conda package can be created from that source distribution, and made available in Conda Forge.

I will use it locally for experimenting with Eyeloop as it's convenient for me when playing with the code. But thought perhaps it could be useful in case there is interest in publishing to PYPI, Conda, or just allowing users to use `pip`/`poetry`/etc.

Cheers
Bruno

ps: updated the docs with what I think would need to be updated, but there are probably other scripts in other folders and other documentation that would need to be updated I think?
ps2: only the package `eyeloop` and the `setup.py` (and `LICENSE` too I think) are part of the final package; before a first release to PYPI, someone would need to define what is included. Some projects opt to include examples and tests, others avoid that. No right or wrong I believe.