### PR TITLE
Fix small typo in misc contributors file

### DIFF
--- a/misc/contributors.md
+++ b/misc/contributors.md
@@ -7,7 +7,7 @@
 EyeLoop is an actively maintained open-source repository based in Yonehara lab at the Danish Research Institute of Translational Neuroscience.
 Contributors are welcome to join in and help improve dynamic eye-tracking tailored toward neuroscientific research.
 
-We are continously improving EyeLoop and adding new features. Artists, programmers, biologists, students, ..., are all welcome.
+We are continuously improving EyeLoop and adding new features. Artists, programmers, biologists, students, ..., are all welcome.
 
 If interested, please do not hesitate to write at: sarv@dandrite.au.dk.
 


### PR DESCRIPTION
Was looking at that folder when troubleshooting why Travis CI was failing (it uses a video that is located in the `misc` directory) and the IDE warned for one typo.

Cheers
Bruno