### PR TITLE
Fix example (open loop) Python errors

### DIFF
--- a/examples/open-loop/plot_loop.py
+++ b/examples/open-loop/plot_loop.py
@@ -6,10 +6,11 @@ import matplotlib.ticker as mticker
 
 
 class Loop_parser(Parser):
-    def __init__(self: Parser):
+    def __init__(self):
+        super().__init__(animal='human')
         self.set_style()
 
-    def custom_lower_panel_ticks(self: Parser, y, pos) -> str:
+    def custom_lower_panel_ticks(self, y, pos) -> str:
         """
         Changes brightness-ticks to 'Dark' and 'Light'.
         """
@@ -19,7 +20,7 @@ class Loop_parser(Parser):
         elif y == 1:
             return "Dark"
 
-    def set_style(self: Parser):
+    def set_style(self):
         """
         Sets the overall style of the plots.
         """
@@ -29,18 +30,18 @@ class Loop_parser(Parser):
         plt.rcParams.update({'font.weight': "regular"})
         plt.rcParams.update({'axes.linewidth': 1})
 
-    def segmentize(self: Parser, key: str) -> np.ndarray:
+    def segmentize(self, key: str) -> np.ndarray:
         """
         Segmentizes the data log based on a key signal, such as a trigger.
         """
 
         segments = []
         for index, entry in enumerate(self.data):
-            if entry[key] == 1:
+            if key in entry and entry[key] == 1:
                 segments.append(index)
         return np.array(segments)
 
-    def plot_open_loop(self: Parser, rows: int = 2, columns: int = 3) -> None:
+    def plot_open_loop(self, rows: int = 2, columns: int = 3) -> None:
         """
         Retrieves and parses the open-loop demo data set.
         """

--- a/examples/open-loop/plot_loop.py
+++ b/examples/open-loop/plot_loop.py
@@ -1,9 +1,5 @@
-import sys
-
-sys.path.append('../')
-
 import numpy as np
-from utilities.parser import Parser
+from eyeloop.utilities.parser import Parser
 import matplotlib.pyplot as plt
 import matplotlib.gridspec as gridspec
 import matplotlib.ticker as mticker

--- a/eyeloop/extractors/converter.py
+++ b/eyeloop/extractors/converter.py
@@ -80,7 +80,7 @@ class Conversion_extractor:
             width, height = dataout["pw"], dataout["ph"]
             pupil, cornea = dataout["pc"], dataout["crc"]
         except Exception as e:
-            print(e)
+            raise Exception(e)
         try:
             pupil_coordinate = self.to_angular(pupil, cornea)
 

--- a/eyeloop/utilities/parser.py
+++ b/eyeloop/utilities/parser.py
@@ -19,7 +19,7 @@ class Parser():
         try:
             file = open(file_path, "r")
         except FileNotFoundError:
-            print("Please select a valid log.")
+            raise ValueError("Please select a valid log.")
         self.file_path = file_path
 
         for line in file.readlines():
@@ -59,7 +59,7 @@ class Parser():
         try:
             import pandas as pd
         except:
-            print("Please make sure that pandas is installed (pip install pandas).")
+            raise Exception("Please make sure that pandas is installed (pip install pandas).")
 
         file = pd.read_json(self.file_path, lines=True)
         new_path = self.file_path + "_csv"

--- a/requirements_examples.txt
+++ b/requirements_examples.txt
@@ -1,0 +1,1 @@
+matplotlib


### PR DESCRIPTION
For #30 . These changes should fix the Python errors found by @raghavprasad13.

- [x] adds a `requirements_examples.txt` with the dependencies required only for examples (only `matplotlib` for now?)
- [x] calls parent constructor to define the `animal` value, using "human" (not sure if the open loop example data is really from human, might have to update it; tested with mouse and the other animal value, same behaviour)
- [x] raises errors when an issue was found, instead of progressing with the code execution; this is to prevent undefined values being accessed in the code, resulting in more errors

However, I've still got an error running the open examples script. Specifically, the JSON log file contains pupil and corner dimensions in `pupil_dim` and `cr_dim` respectivelly. But the code seems to expect `pc` and `crc` fields with these values.

There are also variables for `width` and `height`, but I couldn't find these values in the JSON log file. There are other values such as center of corner and of the pupil, and also the angles. I think the `converter.py` code might need updating to use these values instead?

Hope this helps,
Bruno